### PR TITLE
Get all the pages from do-it and show statistics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,3 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.10.6

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,6 +1,34 @@
 class WelcomeController < ApplicationController
+
   def index
-    response = HTTParty.get("https://api.do-it.org/v1/opportunities\?lat\=51.567526\&lng\=-0.182308\&miles\=2 ")
-    gon.orgs = JSON.parse(response.body)["data"]["items"]
+    # the URL used originally return returned too much data. I changed it for the one provided by Sam 
+    #response = HTTParty.get("https://api.do-it.org/v1/opportunities\?lat\=51.567526\&lng\=-0.182308\&miles\=2 ")
+    host = "https://api.do-it.org"
+    href = "/v1/opportunities?location_id=58b143ec-1033-4fd9-a8c2-d94ae0a18f03&miles=2"
+    js_items = Array.new         # to aggreate the items of all requests -- only the 3 fields used for the map are kept
+    @locations_count = Hash.new  # to count the number of items by location
+    # Loop until the is no "next.href" link returned in the request
+    while href do
+      url = host + href
+      response = HTTParty.get(url)
+      respItems = JSON.parse(response.body)["data"]["items"]
+      respItems.each do |item|
+        js_items.push( { "lat" => item["lat"], "lng" => item["lng"], "title" => item["title"] } )
+        location_key = "lat #{format("%.6f", item["lat"])}, lng #{format("%.6f", item["lng"])}"
+        if @locations_count.has_key? location_key
+          @locations_count[location_key] += 1
+        else
+          @locations_count[location_key] = 1
+        end
+      end
+      nextHash = JSON.parse(response.body)["links"]["next"]
+      href = nextHash ? nextHash["href"] : nil 
+    end
+    gon.orgs = js_items
+    @total_markers_count = js_items.length
+    # Collect statistics from the last response
+    @items_per_page = JSON.parse(response.body)["meta"]["items_per_page"]
+    @total_items = JSON.parse(response.body)["meta"]["total_items"]
+    @total_pages = JSON.parse(response.body)["meta"]["total_pages"]
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
   <title>DoitRails</title>
   <%= include_gon %>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <script src="http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
+  <script src="https://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
 </head>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -5,3 +5,16 @@
 <div id="map-container">
   <div id="map-canvas"></div>
 </div>
+
+<h2>Statistics</h2>
+
+<h3>Global statistics from the last response</h3>
+Items per page: <%= @items_per_page %><br />
+Total numbers of items: <%= @total_items %><br />
+Total number of pages: <%= @total_pages %>
+
+<h3>Number of opportunities per location</h3>
+<%  @locations_count.sort_by {|k,v| v}.reverse.each do |key,value| %>
+   Coordinates: <%= key %>  Number of opportunities: <%= value %> <br />
+<% end %> 
+<p>Total numbers of markers: <%= @total_markers_count %>; number of unique marker locations: <%= @locations_count.length %></p>

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,9 @@ default: &default
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
+  username: postgres
+  password:
+  template: template0
 
 development:
   <<: *default


### PR DESCRIPTION
Important changes:

- read all the pages of a request. I also changed the request because the one used seemed to return too much data (but I am not sure now, I may have misstyped my curl request, sorry for that change...)

- after noticing that the markers announced were not all shown, I added code to see how many unique coordinates were used. It turned out that there can be a lot of markers at the same location, e.g.

```
Coordinates: lat 51.56667000, lng -0.33333000 Number of opportunities: 94 
Coordinates: lat 51.59398000, lng -0.33362000 Number of opportunities: 11 
Coordinates: lat 51.59430000, lng -0.33476900 Number of opportunities: 9 
Coordinates: lat 51.58499000, lng -0.36295000 Number of opportunities: 7 
Coordinates: lat 51.57510000, lng -0.32248100 Number of opportunities: 4 
Coordinates: lat 51.57918000, lng -0.33638000 Number of opportunities: 4 
...
Total numbers of markers: 170; number of unique marker locations: 33
```

- load time is significant, it would be better to have the page load and display the map and make a XMLhttprequest to the doit_rails app so that fetching is not performed while the user is sitting in front of a white page.

Other changes: a few configurations changes to fit my environment: using `https` instead of `http` to load the map api (my test page is loaded with https, so it is required), adding a user in the database yml
